### PR TITLE
A few other fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ class ListPlayer extends EventEmitter { // eslint-disable-line
     this.currentTrack = this.tracks[this.index]
     const source = document.createElement('source')
     source.src = this.currentTrack.src
-    source.type = 'audio/mp3'
+    source.type = this.currentTrack.type || 'audio/mp3'
 
     this.el.appendChild(source)
     this.el.load()

--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,7 @@ class ListPlayer extends EventEmitter { // eslint-disable-line
    */
   _loadTrack () {
     if (this._loadedTrack === this.index) return
+    if (this.tracks.length === 0) return
     this.el.innerHTML = ''
 
     this.currentTrack = this.tracks[this.index]


### PR DESCRIPTION
1. Currently when no tracks are specified it fails during startup. It does make sense sometimes to pre-create a player when there are no tracks yet (i. e. to load different playlists later, [example](https://github.com/Songbee/desktop/blob/de29080418824dbffe6532b562e790f3b1a77481/src/torrents.js)).

2. Also, although it seems to work even with incorrect MIME types (if the files aren't MP3), it's still better to let the user specify it.